### PR TITLE
Added newest Postman collections for ChatDoctor tutorial

### DIFF
--- a/tutorials/ChatDoctor.ipynb
+++ b/tutorials/ChatDoctor.ipynb
@@ -278,7 +278,7 @@
    ],
    "source": [
     "# Downloading Dataset_v2 from Lynxius platform\n",
-    "dataset_details = client.get_dataset_details(dataset_id=\"e4ae0876-692f-415e-a2c5-924d92575a92\")\n",
+    "dataset_details = client.get_dataset_details(dataset_id=\"DATASET_V2_LABELED_UUID\")\n",
     "\n",
     "for entry in dataset_details.entries:\n",
     "    print(entry.query)"

--- a/tutorials/data/postman/Lynxius_ChatDoctor_Project_1_of_3.postman_collection.json
+++ b/tutorials/data/postman/Lynxius_ChatDoctor_Project_1_of_3.postman_collection.json
@@ -89,7 +89,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"name\": \"ChatDoctor v_0001\"\n}",
+					"raw": "{\n  \"name\": \"ChatDoctor\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -172,7 +172,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							""
+							"var responseData = pm.response.json();",
+							"postman.setEnvironmentVariable('dataset_uuid', responseData.uuid);"
 						],
 						"type": "text/javascript",
 						"packages": {}
@@ -196,63 +197,6 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n  \"project_uuid\": \"{{project_uuid}}\",\n  \"name\": \"Dataset v1\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{base_url}}/api/datasets/",
-					"host": [
-						"{{base_url}}"
-					],
-					"path": [
-						"api",
-						"datasets",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Dataset (bug: UUID not returned)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var responseData = pm.response.json();",
-							"var projects = responseData.owner_of;",
-							"var targetProjectName = \"Dataset v1\";",
-							"",
-							"// Loop through each project in the owner_of array",
-							"var projectUUID = projects.find(project => project.name === targetProjectName).uuid;",
-							"",
-							"// Set the project UUID as an environment variable",
-							"pm.environment.set('dataset_uuid', projectUUID);"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "accept",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/tutorials/data/postman/Lynxius_ChatDoctor_Project_2_of_3.postman_collection.json
+++ b/tutorials/data/postman/Lynxius_ChatDoctor_Project_2_of_3.postman_collection.json
@@ -13,7 +13,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							""
+							"var responseData = pm.response.json();",
+							"postman.setEnvironmentVariable('dataset_uuid', responseData.uuid);"
 						],
 						"type": "text/javascript",
 						"packages": {}
@@ -37,63 +38,6 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n  \"project_uuid\": \"{{project_uuid}}\",\n  \"name\": \"Dataset v2\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{base_url}}/api/datasets/",
-					"host": [
-						"{{base_url}}"
-					],
-					"path": [
-						"api",
-						"datasets",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Dataset (bug: UUID not returned)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var responseData = pm.response.json();",
-							"var projects = responseData.owner_of;",
-							"var targetProjectName = \"Dataset v2\";",
-							"",
-							"// Loop through each project in the owner_of array",
-							"var projectUUID = projects.find(project => project.name === targetProjectName).uuid;",
-							"",
-							"// Set the project UUID as an environment variable",
-							"pm.environment.set('dataset_uuid', projectUUID);"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "accept",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/tutorials/data/postman/Lynxius_ChatDoctor_Project_3_of_3.postman_collection.json
+++ b/tutorials/data/postman/Lynxius_ChatDoctor_Project_3_of_3.postman_collection.json
@@ -13,7 +13,8 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							""
+							"var responseData = pm.response.json();",
+							"postman.setEnvironmentVariable('dataset_uuid', responseData.uuid);"
 						],
 						"type": "text/javascript",
 						"packages": {}
@@ -37,63 +38,6 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n  \"project_uuid\": \"{{project_uuid}}\",\n  \"name\": \"Dataset v2-labeled\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{base_url}}/api/datasets/",
-					"host": [
-						"{{base_url}}"
-					],
-					"path": [
-						"api",
-						"datasets",
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Dataset (bug: UUID not returned)",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"var responseData = pm.response.json();",
-							"var projects = responseData.owner_of;",
-							"var targetProjectName = \"Dataset v2-labeled\";",
-							"",
-							"// Loop through each project in the owner_of array",
-							"var projectUUID = projects.find(project => project.name === targetProjectName).uuid;",
-							"",
-							"// Set the project UUID as an environment variable",
-							"pm.environment.set('dataset_uuid', projectUUID);"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "accept",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
This PR reflects the changes of PR [#115](https://github.com/lynxius/lynxius-webapp/pull/115) for the webapp.

The Postman collections for the ChatDoctor tutorial now fetch the UUID of the newly created Datasets directly from the response of the POST request to `/api/datasets/`. Calling GET `/api/datasets/` is no longer necessary.