### PR TITLE
Add support for baseline comparison

### DIFF
--- a/lynxius/evals/answer_correctness.py
+++ b/lynxius/evals/answer_correctness.py
@@ -13,12 +13,16 @@ class AnswerCorrectness(Evaluator):
         label: str,
         href: str = None,
         tags: list[str] = [],
+        baseline_project_uuid: str = None,
+        baseline_eval_run_label: str = None,
     ):
         [Evaluator.validate_tag(value) for value in tags]
 
         self.label = label
         self.href = href
         self.tags = tags
+        self.baseline_project_uuid = baseline_project_uuid
+        self.baseline_eval_run_label = baseline_eval_run_label
         self.samples = []
         self.evaluated_results = None
 
@@ -48,6 +52,8 @@ class AnswerCorrectness(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "version": "1",
                 "data": [
                     {
@@ -67,6 +73,8 @@ class AnswerCorrectness(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "data": [
                     {
                         "query": item[0],

--- a/lynxius/evals/bert_score.py
+++ b/lynxius/evals/bert_score.py
@@ -12,6 +12,8 @@ class BertScore(Evaluator):
         presence_threshold: float = 0.65,
         href: str = None,
         tags: list[str] = [],
+        baseline_project_uuid: str = None,
+        baseline_eval_run_label: str = None,
     ):
         levels = ["word", "sentence"]
         if level not in levels:
@@ -22,6 +24,8 @@ class BertScore(Evaluator):
         self.label = label
         self.href = href
         self.tags = tags
+        self.baseline_project_uuid = baseline_project_uuid
+        self.baseline_eval_run_label = baseline_eval_run_label
         self.level = level
         self.presence_threshold = presence_threshold
         self.samples = []
@@ -47,6 +51,8 @@ class BertScore(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "level": self.level,
                 "presence_threshold": self.presence_threshold,
                 "version": "1",
@@ -68,6 +74,8 @@ class BertScore(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "level": self.level,
                 "presence_threshold": self.presence_threshold,
                 "data": [

--- a/lynxius/evals/context_precision.py
+++ b/lynxius/evals/context_precision.py
@@ -13,12 +13,16 @@ class ContextPrecision(Evaluator):
         label: str,
         href: str = None,
         tags: list[str] = [],
+        baseline_project_uuid: str = None,
+        baseline_eval_run_label: str = None,
     ):
         [Evaluator.validate_tag(value) for value in tags]
 
         self.label = label
         self.href = href
         self.tags = tags
+        self.baseline_project_uuid = baseline_project_uuid
+        self.baseline_eval_run_label = baseline_eval_run_label
         self.samples = []
         self.evaluated_results = None
 
@@ -46,6 +50,8 @@ class ContextPrecision(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "version": "1",
                 "data": [
                     {
@@ -64,6 +70,8 @@ class ContextPrecision(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "data": [
                     {
                         "query": item[0],

--- a/lynxius/evals/custom_eval.py
+++ b/lynxius/evals/custom_eval.py
@@ -15,12 +15,16 @@ class CustomEval(Evaluator):
         name: str = None,
         href: str = None,
         tags: list[str] = [],
+        baseline_project_uuid: str = None,
+        baseline_eval_run_label: str = None,
     ):
         [Evaluator.validate_tag(value) for value in tags]
 
         self.label = label
         self.href = href
         self.tags = tags
+        self.baseline_project_uuid = baseline_project_uuid
+        self.baseline_eval_run_label = baseline_eval_run_label
         self.prompt_template = prompt_template
         self.name_override = name
         self.samples = []
@@ -60,6 +64,8 @@ class CustomEval(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "prompt_template": self.prompt_template,
                 "name_override": self.name_override,
                 "version": "1",
@@ -79,6 +85,8 @@ class CustomEval(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "prompt_template": self.prompt_template,
                 "name_override": self.name_override,
                 "data": [

--- a/lynxius/evals/json_diff.py
+++ b/lynxius/evals/json_diff.py
@@ -9,12 +9,16 @@ class JsonDiff(Evaluator):
         label: str,
         href: str = None,
         tags: list[str] = [],
+        baseline_project_uuid: str = None,
+        baseline_eval_run_label: str = None,
     ):
         [Evaluator.validate_tag(value) for value in tags]
 
         self.label = label
         self.href = href
         self.tags = tags
+        self.baseline_project_uuid = baseline_project_uuid
+        self.baseline_eval_run_label = baseline_eval_run_label
         self.samples = []
         self.evaluated_results = None
 
@@ -66,6 +70,8 @@ class JsonDiff(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "version": "1",
                 "data": [
                     {
@@ -83,6 +89,8 @@ class JsonDiff(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "data": [
                     {
                         "reference": item[0],

--- a/lynxius/evals/semantic_similarity.py
+++ b/lynxius/evals/semantic_similarity.py
@@ -10,12 +10,16 @@ class SemanticSimilarity(Evaluator):
         label: str,
         href: str = None,
         tags: list[str] = [],
+        baseline_project_uuid: str = None,
+        baseline_eval_run_label: str = None,
     ):
         [Evaluator.validate_tag(value) for value in tags]
 
         self.label = label
         self.href = href
         self.tags = tags
+        self.baseline_project_uuid = baseline_project_uuid
+        self.baseline_eval_run_label = baseline_eval_run_label
         self.samples = []
         self.evaluated_results = None
 
@@ -43,6 +47,8 @@ class SemanticSimilarity(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "version": "1",
                 "data": [
                     {
@@ -59,6 +65,8 @@ class SemanticSimilarity(Evaluator):
                 "label": self.label,
                 "href": self.href,
                 "tags": self.tags,
+                "baseline_project_uuid": self.baseline_project_uuid,
+                "baseline_eval_run_label": self.baseline_eval_run_label,
                 "data": [
                     {
                         "reference": item[0],

--- a/tutorials/eval_baseline.ipynb
+++ b/tutorials/eval_baseline.ipynb
@@ -1,0 +1,419 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "19766bca-b0e3-48dc-be4b-8ed8612d02ad",
+   "metadata": {},
+   "source": [
+    "# Comparison against the baseline\n",
+    "\n",
+    "Integrating Lynxius directly into your CI/CD pipeline makes it straightforward to determine whether a pull request introduces a regression or enhances the performance of your LLM-powered application.\n",
+    "\n",
+    "Lynxius makes it easy to ensure that each pull request is thoroughly tested and compared against a baseline. The baseline consists of the same set of queries and ground truth outputs run against the master branch of your repository, excluding the changes from the pull request. This precise comparison helps your development team quickly identify regressions, ensuring the quality of your LLM-powered application, at every step of the way.\n",
+    "\n",
+    "Setting up your testing pipeline like this ensures that your team can iterate over your codebase swiftly and confidently, making it easier to maintain and improve your application.\n",
+    "\n",
+    "For this to work, we'll have to run the same set of evaluations twice:\n",
+    "1. Whenever the master branch of your application is updated (or a nightly cron job, for example),\n",
+    "2. and whenever a pull request is made\n",
+    "\n",
+    "The first set of evaluations is called the baseline. Simply put, the baseline indicates the performance of your application on a master branch. Whenever you want to make a change to your application and make a pull request, you want to ensure that this change indeed improves the performance of your system and doesn't introduce any unwanted side effects or regressions. For this, we set up testing against the baseline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ae34a5e7-6be5-424e-bbb9-1f480ffca740",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from getpass import getpass\n",
+    "sys.path.append(\"../\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0812cce7-b8e3-44a0-a944-5ab46c5acffc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Makes it easier to iterate\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c130b4a8-c7dd-4c72-af33-90036a9200e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "🔑 Enter your OpenAI API key:  ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "# We'll be using OpenAI to evaluate locally so we have to set the API key\n",
+    "if not (openai_api_key := os.getenv(\"OPENAI_API_KEY\")):\n",
+    "    openai_api_key = getpass(\"🔑 Enter your OpenAI API key: \")\n",
+    "os.environ[\"OPENAI_API_KEY\"] = openai_api_key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a8e2fffc-0345-48f7-8d5d-2790db090f60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Our sample LLM application\n",
+    "from datasets_utils import chatdoctor_v1\n",
+    "\n",
+    "# Lynxius client comunicates with the Lynxius online platform\n",
+    "from lynxius.client import LynxiusClient\n",
+    "\n",
+    "# Importing the evaluators\n",
+    "from lynxius.evals.bert_score import BertScore\n",
+    "from lynxius.evals.answer_correctness import AnswerCorrectness\n",
+    "from lynxius.evals.semantic_similarity import SemanticSimilarity\n",
+    "from lynxius.evals.custom_eval import CustomEval\n",
+    "from lynxius.evals.context_precision import ContextPrecision\n",
+    "from lynxius.evals.json_diff import JsonDiff\n",
+    "\n",
+    "# ContextChunk represents a document retrieved from you RAG system\n",
+    "from lynxius.rag.types import ContextChunk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "856e37c0-db9f-4445-83c4-676bde2cbd79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here we define sample RAG contexts.\n",
+    "# Retrieval of context documents depends on the RAG database that you're using\n",
+    "context = [\n",
+    "    ContextChunk(document=\"Avoid close contact with people who are sick. When you are sick, keep your distance from others to protect them from getting sick, too.\", relevance=0.75),\n",
+    "    ContextChunk(document=\"If possible, stay home from work, school, and errands when you’re sick. You can go back to your normal activities when, for at least 24 hours, both are true:\", relevance=0.31)\n",
+    "]\n",
+    "\n",
+    "# Define tags to make it easier to locate these eval runs on the Lynxius platform\n",
+    "tags = [\"notebook\", \"experiment\", \"baseline\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "23f6af69-9fb6-4ba6-8fa4-8f04702f542e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lynxius allows you to use your own evaluator templates\n",
+    "# Let's define and use one!\n",
+    "\n",
+    "# When using a custom template, the only thing that you need to ensure is that\n",
+    "# the final verdict is printed at the very bottom of the resonse, with no other characters.\n",
+    "custom_eval_template = \"\"\"\n",
+    "You are given a question, a reference answer and a candidate answer concerning a clinical matter.\n",
+    "You must determine if the candidate answer covers exactly the same content as the reference answer.\n",
+    "If the candidate answer contains additional information, or fails to mention something that is present\n",
+    "in the reference answer, your verdict should be 'incorrect'. Otherwise, your verdict should be 'correct'.\n",
+    "Provide a short explanation about how you arrived to your verdict. The verdict must be printed at the\n",
+    "very bottom of your response, on a new line, and it must not contain any extra characters.\n",
+    "Here is the data:\n",
+    "***********\n",
+    "Query: {query}\n",
+    "***********\n",
+    "Reference answer: {reference}\n",
+    "***********\n",
+    "Candidate answer: {output}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "08343534-556e-4262-a31c-c604f43121a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We recommend storing baseline eval runs and test eval runs in separate projects.\n",
+    "# That's what we will do here so we'll need to use 2 Lynxius API keys, one for each project.\n",
+    "# The following keys are left here for the sake of example - they're not operational. Please use your API keys.\n",
+    "\n",
+    "testing_lynxius_api_key = \"PU7Mf8iDMVcH2ElMaabChQP6zkLqb2cTbrlfnIagGAuHhWyj\"\n",
+    "baseline_lynxius_api_key = \"gJ64Mgtv78DeEABavgxNGlyuGXEoPReUFtWrCel31wDU2Psy\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "38e18547-bdb9-4d55-a79d-9a47a64c7918",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'6d32201a-7cc8-4c47-aa5c-e43cfb0efc7c'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ================================================================================================\n",
+    "# This code runs on every merge to a master branch or, alternativelly, in a nightly cron job.\n",
+    "# ================================================================================================\n",
+    "\n",
+    "client_baseline = LynxiusClient(api_key=baseline_lynxius_api_key, run_local=True)\n",
+    "dataset_details = client_baseline.get_dataset_details(dataset_id=\"6e83cec5-d8d3-4237-af9e-8d4b7c71a2ce\")\n",
+    "\n",
+    "# Define and run the evals\n",
+    "bert_score = BertScore(\"master_baseline_sample\", level=\"word\", presence_threshold=0.65, tags=tags)\n",
+    "answer_correctness = AnswerCorrectness(\"master_baseline_sample\", tags=tags)\n",
+    "semantic_similarity = SemanticSimilarity(\"master_baseline_sample\", tags=tags)\n",
+    "custom_eval = CustomEval(\"master_baseline_sample\", name=\"clinical_correctness\", prompt_template=custom_eval_template, tags=tags)\n",
+    "context_precision = ContextPrecision(\"master_baseline_sample\", tags=tags)\n",
+    "\n",
+    "for entry in dataset_details.entries:\n",
+    "    # Query your LLM\n",
+    "    actual_output = chatdoctor_v1(entry.query)\n",
+    "\n",
+    "    # Add traces to the evals\n",
+    "    bert_score.add_trace(reference=entry.reference, output=actual_output, context=context)\n",
+    "    answer_correctness.add_trace(query=entry.query, reference=entry.reference, output=actual_output, context=context)\n",
+    "    semantic_similarity.add_trace(reference=entry.reference, output=actual_output, context=context)\n",
+    "    custom_eval.add_trace(values={\"query\": entry.query, \"reference\": entry.reference, \"output\": actual_output}, context=context)\n",
+    "    context_precision.add_trace(query=entry.query, reference=entry.reference, context=context)\n",
+    "\n",
+    "# Run evals locally and store results in the Lynxius platform\n",
+    "client_baseline.evaluate(bert_score)\n",
+    "client_baseline.evaluate(answer_correctness)\n",
+    "client_baseline.evaluate(semantic_similarity)\n",
+    "client_baseline.evaluate(custom_eval)\n",
+    "client_baseline.evaluate(context_precision)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "699b38bd-bec6-41fb-a953-5f19ff732eb4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'b89e92d5-d6d9-4a85-89df-fda762ddeeef'"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_diff = JsonDiff(\"master_baseline_sample\", tags=tags)\n",
+    "\n",
+    "ref = {\n",
+    "    \"prop1\": True,\n",
+    "    \"prop2\": True,\n",
+    "    \"prop3\": {\n",
+    "      \"prop4\": True,\n",
+    "      \"prop5\": True\n",
+    "    }\n",
+    "}\n",
+    "output = {\n",
+    "    \"prop1\": True,\n",
+    "    \"prop2\": True,\n",
+    "    \"prop3\": {\n",
+    "      \"prop4\": True,\n",
+    "      \"prop5\": False\n",
+    "    }\n",
+    "}\n",
+    "weights = {\n",
+    "    \"prop1\": 1.0,\n",
+    "    \"prop2\": 1.0,\n",
+    "    \"prop3\": {\n",
+    "        \"prop4\": 0.5,\n",
+    "        \"__prop3\": 0.7,\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "json_diff.add_trace(reference=ref, output=output, weights=weights, context=context)\n",
+    "client_baseline.evaluate(json_diff)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "f8deca5d-d154-4685-989a-046cba202a40",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'4ad28507-d797-44e7-aef9-27ecb87ddf2d'"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# ================================================================================================\n",
+    "# This code runs whenever a pull request is made or updated. Here we will reference the baseline.\n",
+    "# ================================================================================================\n",
+    "\n",
+    "client_testing = LynxiusClient(api_key=testing_lynxius_api_key, run_local=True)\n",
+    "# Download the same dataset!!!\n",
+    "dataset_details = client_testing.get_dataset_details(dataset_id=\"6e83cec5-d8d3-4237-af9e-8d4b7c71a2ce\")\n",
+    "\n",
+    "# This is the ID of a project where the baseline eval runs are stored. \n",
+    "# You can get it by visiting the project details page on the Lynxius Platform\n",
+    "baseline_project_uuid = \"a9f1e445-fe16-430e-977e-33e954baa568\"\n",
+    "# This is label that we've assigned to our baseline eval runs earlier\n",
+    "baseline_eval_run_label = \"master_baseline_sample\"\n",
+    "\n",
+    "# Define and run the evals\n",
+    "bert_score = BertScore(\n",
+    "    \"PR #123\",\n",
+    "    level=\"word\",\n",
+    "    presence_threshold=0.65,\n",
+    "    tags=tags,\n",
+    "    baseline_project_uuid=baseline_project_uuid,\n",
+    "    baseline_eval_run_label=baseline_eval_run_label,\n",
+    ")\n",
+    "answer_correctness = AnswerCorrectness(\n",
+    "    \"PR #123\",\n",
+    "    tags=tags,\n",
+    "    baseline_project_uuid=baseline_project_uuid,\n",
+    "    baseline_eval_run_label=baseline_eval_run_label,\n",
+    ")\n",
+    "semantic_similarity = SemanticSimilarity(\n",
+    "    \"PR #123\",\n",
+    "    tags=tags,\n",
+    "    baseline_project_uuid=baseline_project_uuid,\n",
+    "    baseline_eval_run_label=baseline_eval_run_label,\n",
+    ")\n",
+    "custom_eval = CustomEval(\n",
+    "    \"PR #123\",\n",
+    "    name=\"PR #123\",\n",
+    "    prompt_template=custom_eval_template,\n",
+    "    tags=tags,\n",
+    "    baseline_project_uuid=baseline_project_uuid,\n",
+    "    baseline_eval_run_label=baseline_eval_run_label,\n",
+    ")\n",
+    "context_precision = ContextPrecision(\n",
+    "    \"PR #123\",\n",
+    "    tags=tags,\n",
+    "    baseline_project_uuid=baseline_project_uuid,\n",
+    "    baseline_eval_run_label=baseline_eval_run_label,\n",
+    ")\n",
+    "\n",
+    "for entry in dataset_details.entries:\n",
+    "    # Query your LLM\n",
+    "    actual_output = chatdoctor_v1(entry.query)\n",
+    "\n",
+    "    # Add traces to the evals\n",
+    "    bert_score.add_trace(reference=entry.reference, output=actual_output, context=context)\n",
+    "    answer_correctness.add_trace(query=entry.query, reference=entry.reference, output=actual_output, context=context)\n",
+    "    semantic_similarity.add_trace(reference=entry.reference, output=actual_output, context=context)\n",
+    "    custom_eval.add_trace(values={\"query\": entry.query, \"reference\": entry.reference, \"output\": actual_output}, context=context)\n",
+    "    context_precision.add_trace(query=entry.query, reference=entry.reference, context=context)\n",
+    "\n",
+    "# Run evals locally and store results in the Lynxius platform\n",
+    "client_testing.evaluate(bert_score)\n",
+    "client_testing.evaluate(answer_correctness)\n",
+    "client_testing.evaluate(semantic_similarity)\n",
+    "client_testing.evaluate(custom_eval)\n",
+    "client_testing.evaluate(context_precision)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "b1ab8c6c-190a-490c-bc66-c2616e7140aa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'7664abd0-f997-4698-82f0-269b8c5a57ec'"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_diff = JsonDiff(\n",
+    "    \"PR #123\",\n",
+    "    tags=tags,\n",
+    "    baseline_project_uuid=baseline_project_uuid,\n",
+    "    baseline_eval_run_label=baseline_eval_run_label,\n",
+    ")\n",
+    "\n",
+    "ref = {\n",
+    "    \"prop1\": True,\n",
+    "    \"prop2\": True,\n",
+    "    \"prop3\": {\n",
+    "      \"prop4\": True,\n",
+    "      \"prop5\": True\n",
+    "    }\n",
+    "}\n",
+    "output = {\n",
+    "    \"prop1\": True,\n",
+    "    \"prop2\": True,\n",
+    "    \"prop3\": {\n",
+    "      \"prop4\": True,\n",
+    "      \"prop5\": False\n",
+    "    }\n",
+    "}\n",
+    "weights = {\n",
+    "    \"prop1\": 1.0,\n",
+    "    \"prop2\": 1.0,\n",
+    "    \"prop3\": {\n",
+    "        \"prop4\": 0.5,\n",
+    "        \"__prop3\": 0.7,\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "json_diff.add_trace(reference=ref, output=output, weights=weights, context=context)\n",
+    "client_testing.evaluate(json_diff)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/eval_baseline.ipynb
+++ b/tutorials/eval_baseline.ipynb
@@ -255,17 +255,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "f8deca5d-d154-4685-989a-046cba202a40",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'4ad28507-d797-44e7-aef9-27ecb87ddf2d'"
+       "'dcd91d4a-bade-4406-83e4-5bee8844daa6'"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,7 +308,7 @@
     ")\n",
     "custom_eval = CustomEval(\n",
     "    \"PR #123\",\n",
-    "    name=\"PR #123\",\n",
+    "    name=\"clinical_correctness\",\n",
     "    prompt_template=custom_eval_template,\n",
     "    tags=tags,\n",
     "    baseline_project_uuid=baseline_project_uuid,\n",
@@ -342,17 +342,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "id": "b1ab8c6c-190a-490c-bc66-c2616e7140aa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'7664abd0-f997-4698-82f0-269b8c5a57ec'"
+       "'c5632d74-089c-4c3d-9290-0d2b7ed0ae84'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Every evaluator now has 2 more parameters (`baseline_project_uuid` and `baseline_eval_run_label`) that are used to identify the eval run that should be used a baseline for current eval run.
Please refer to a newly added notebook for more details on how to compare eval runs against a baseline.